### PR TITLE
feat: add Portuguese translations for frontend component extended fields

### DIFF
--- a/translations/frontend-component-extended-fields/src/i18n/messages/pt.json
+++ b/translations/frontend-component-extended-fields/src/i18n/messages/pt.json
@@ -1,0 +1,11 @@
+{
+  "profile.formcontrols.who.can.see": "Quem pode ver isto:",
+  "profile.formcontrols.button.cancel": "Cancelar",
+  "profile.formcontrols.button.save": "Guardar",
+  "profile.formcontrols.button.saving": "A guardar",
+  "profile.formcontrols.button.saved": "Guardado",
+  "profile.formcontrols.error.min_length": "Este campo deve ter pelo menos {minLength} caracteres.",
+  "profile.formcontrols.error.max_length": "Este campo deve ter no máximo {maxLength} caracteres.",
+  "account.settings.editable.field.action.edit": "Editar",
+  "account.settings.editable.field.action.add": "Adicionar {fieldLabel}"
+}

--- a/translations/frontend-component-extended-fields/src/i18n/messages/pt_PT.json
+++ b/translations/frontend-component-extended-fields/src/i18n/messages/pt_PT.json
@@ -1,0 +1,11 @@
+{
+  "profile.formcontrols.who.can.see": "Quem pode ver isto:",
+  "profile.formcontrols.button.cancel": "Cancelar",
+  "profile.formcontrols.button.save": "Guardar",
+  "profile.formcontrols.button.saving": "A guardar",
+  "profile.formcontrols.button.saved": "Guardado",
+  "profile.formcontrols.error.min_length": "Este campo deve ter pelo menos {minLength} caracteres.",
+  "profile.formcontrols.error.max_length": "Este campo deve ter no máximo {maxLength} caracteres.",
+  "account.settings.editable.field.action.edit": "Editar",
+  "account.settings.editable.field.action.add": "Adicionar {fieldLabel}"
+}

--- a/translations/frontend-component-extended-fields/src/i18n/transifex_input.json
+++ b/translations/frontend-component-extended-fields/src/i18n/transifex_input.json
@@ -1,0 +1,11 @@
+{
+  "profile.formcontrols.who.can.see": "Who can see this:",
+  "profile.formcontrols.button.cancel": "Cancel",
+  "profile.formcontrols.button.save": "Save",
+  "profile.formcontrols.button.saving": "Saving",
+  "profile.formcontrols.button.saved": "Saved",
+  "profile.formcontrols.error.min_length": "This field must be at least {minLength} characters long.",
+  "profile.formcontrols.error.max_length": "This field must be at most {maxLength} characters long.",
+  "account.settings.editable.field.action.edit": "Edit",
+  "account.settings.editable.field.action.add": "Add {fieldLabel}"
+}


### PR DESCRIPTION
This pull request adds new translation strings for profile form controls and account settings fields in English, Portuguese (Brazil), and Portuguese (Portugal). These additions support improved localization and user experience for editing and displaying profile and account settings fields.

**Translation additions:**

* Added English source strings for profile form controls and editable account settings fields in `transifex_input.json`.
* Added Portuguese (Brazil) translations for the same strings in `pt.json`.
* Added Portuguese (Portugal) translations for the same strings in `pt_PT.json`.